### PR TITLE
The detected configuration is always placed first

### DIFF
--- a/rofi-autorandr.sh
+++ b/rofi-autorandr.sh
@@ -5,7 +5,8 @@ set -e
 
 function get_layouts()
 {
-    autorandr
+    autorandr | grep " (detected)"
+    autorandr | grep --invert-match " (detected)"
 }
 
 function main()


### PR DESCRIPTION
This PR changes the order of the entries: the `autorandr` entry that contains " (detected)" will be placed as the first entry in the Rofi menu.

I find this order very convenient, as it supports returning to the detected setting after having changed the setting manually.